### PR TITLE
Change from recursive to while loop

### DIFF
--- a/lib/syntax-check-linter.coffee
+++ b/lib/syntax-check-linter.coffee
@@ -2,11 +2,18 @@
 helpers = require('atom-linter')
 path = require('path')
 
-getLibDir = (p) ->
-  dotdot = path.dirname(p)
-  return dotdot if dotdot in atom.project.getPaths()
-  return dotdot if path.basename(dotdot) is 'lib'
-  getLibDir(dotdot)
+getLibDir = (filepath) ->
+  projpaths = atom.project.getPaths()
+  home =
+    if process.platform.startsWith 'win'
+    then process.env.HOMEPATH else process.env.HOME
+  curpath = path.dirname filepath
+  while curpath != path.dirname(curpath)
+    return false if curpath in projpaths
+    return false if curpath is home
+    return "-I#{curpath}" if path.basename(curpath) is 'lib'
+    curpath = path.dirname curpath
+  return false
 
 # This provides linter support for Perl 6 using linter
 # Please see https://atom.io/packages/linter


### PR DESCRIPTION
### Changes
- Better guarding of infinite loop
- Windows HOMEPATH support

Note: maybe this should be included optionally as perl6 will loop out-of-control if their is a circular dependency.  On my machine perl6 created hundreds of `moar` processes until I lost any ability to interact with my computer.  One time, I was able to get in to a terminal and start killing these but it would just infinitely create more and I merely slowed down the process.

Another option would be to search all files for `use` statements and check for circular dependencies before running `perl6 -c`.  This could be a nifty addition to this package: check dependencies, check for circular dependencies, and maybe even write to the `META6.json` file.
