### PR TITLE
Fix Missing html/text field on Linter Response

### DIFF
--- a/lib/syntax-check-linter.js
+++ b/lib/syntax-check-linter.js
@@ -7,7 +7,7 @@ path    = require('path')
 // Please see https://atom.io/packages/linter
 module.exports =
 class Perl6LinterProvider {
-  
+
   constructor() {
     this.name          = 'Perl 6 Syntax Check'
     this.grammarScopes = ['source.perl6', 'source.perl6fe']
@@ -35,7 +35,7 @@ class Perl6LinterProvider {
     return helpers.exec(command, args, options).then( (output) => {
 
       // return nothing if no errors are found
-      if (output.stdout.endsWith("Syntax OK\n") && output.stderr == "") {
+      if (output.stdout.match(/Syntax OK\n?/i) && output.stderr == "") {
         return []
       }
 
@@ -49,7 +49,7 @@ class Perl6LinterProvider {
         line    = match[2] - 1
       } else {
         // We failed, at least show the message without line number information
-        message = stderr.replace("===SORRY!===", "")
+        message = stderr.replace(/===(.*)===/, "")
         line    = 0
       }
 


### PR DESCRIPTION
Be less strict on matching "Syntax OK".

Remove any ===HEADER=== the linter may return.

Hopefully fixes #19
