### PR TITLE
fix lint provider to work with latest Atom

### DIFF
--- a/lib/syntax-check-linter.js
+++ b/lib/syntax-check-linter.js
@@ -29,13 +29,13 @@ class Perl6LinterProvider {
 
     options = {
       cwd: projectDir,
-      stream : "",
+      stream : "both",
       stdin  : textEditor.getText()
     }
     return helpers.exec(command, args, options).then( (output) => {
 
       // return nothing if no errors are found
-      if (output.stdout.endsWith("Syntax OK\n") && output.stderr == "") {
+      if (output.stdout.endsWith("Syntax OK") && output.stderr == "") {
         return []
       }
 


### PR DESCRIPTION
linter was broken for me.  This fixes it for the most part.  The regex doesn't pick up the line number in certain conditions.

Tested in linux and windows 10. 
